### PR TITLE
Add isolated component screenshot tests for all story variants

### DIFF
--- a/android/app/src/androidTest/java/com/testapp/ComponentSurfaceTest.kt
+++ b/android/app/src/androidTest/java/com/testapp/ComponentSurfaceTest.kt
@@ -1,0 +1,59 @@
+package com.rnstorybookautoscreenshots
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class ComponentSurfaceTest(private val componentName: String) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun components() = listOf(
+            // Base components
+            arrayOf("MyFeature"),
+            arrayOf("SwitchFeature"),
+            arrayOf("TimerFeature"),
+            arrayOf("CoinFlipFeature"),
+            arrayOf("Button"),
+            arrayOf("Header"),
+
+            // Button story variants
+            arrayOf("Button_Primary"),
+            arrayOf("Button_Secondary"),
+            arrayOf("Button_Large"),
+            arrayOf("Button_Small"),
+
+            // Header story variants
+            arrayOf("Header_LoggedIn"),
+            arrayOf("Header_LoggedOut"),
+
+            // MyFeature story variants
+            arrayOf("MyFeature_Initial"),
+            arrayOf("MyFeature_WithClicks"),
+            arrayOf("MyFeature_ManyClicks"),
+
+            // SwitchFeature story variants
+            arrayOf("SwitchFeature_Off"),
+            arrayOf("SwitchFeature_On"),
+
+            // TimerFeature story variants
+            arrayOf("TimerFeature_Initial"),
+            arrayOf("TimerFeature_Running"),
+            arrayOf("TimerFeature_Paused"),
+            arrayOf("TimerFeature_LongDuration"),
+
+            // CoinFlipFeature story variants
+            arrayOf("CoinFlipFeature_Default"),
+            arrayOf("CoinFlipFeature_Heads"),
+            arrayOf("CoinFlipFeature_Tails"),
+            arrayOf("CoinFlipFeature_ManyFlips"),
+        )
+    }
+
+    @Test
+    fun screenshot() {
+        ReactHostFixture.screenshotComponent(componentName)
+    }
+}

--- a/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
+++ b/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
@@ -1,8 +1,17 @@
 package com.rnstorybookautoscreenshots
 
+import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.testapp.MainApplication
+import com.facebook.react.PackageList
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.bridge.JSBundleLoader
+import com.facebook.react.defaults.DefaultComponentsRegistry
+import com.facebook.react.defaults.DefaultReactHostDelegate
+import com.facebook.react.defaults.DefaultTurboModuleManagerDelegate
+import com.facebook.react.fabric.ComponentFactory
+import com.facebook.react.runtime.ReactHostImpl
+import com.facebook.react.runtime.hermes.HermesInstance
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
 import org.junit.Test
@@ -19,16 +28,36 @@ class IsolatedTest {
         assertTrue(true)
     }
 
+    @OptIn(UnstableReactNativeAPI::class)
     @Test
     fun constructViewTest() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val app = context.applicationContext as MainApplication
-        val surface = app.reactHost.createSurface(context, "SimpleTestComponent", null)
+        val app = context.applicationContext as Application
+
+        val bundleLoader = JSBundleLoader.createAssetLoader(
+            context, "assets://index.android.bundle", true)
+        val delegate = DefaultReactHostDelegate(
+            jsMainModulePath = "index",
+            jsBundleLoader = bundleLoader,
+            reactPackages = PackageList(app).packages,
+            jsRuntimeFactory = HermesInstance(),
+            turboModuleManagerDelegateBuilder = DefaultTurboModuleManagerDelegate.Builder(),
+            exceptionHandler = { throw it },
+        )
+        val componentFactory = ComponentFactory()
+        DefaultComponentsRegistry.register(componentFactory)
+        val reactHost = ReactHostImpl(
+            context,
+            delegate,
+            componentFactory,
+            false, // allowPackagerServerAccess
+            false, // useDevSupport
+        )
+
+        val surface = reactHost.createSurface(context, "SimpleTestComponent", null)
         assertEquals("SimpleTestComponent", surface.moduleName)
 
         // TODO: we aren't 100% sure if prerender() and start() are being called the way we want it to.
-        // We probably want to create a ReactHost directly instead of taking it from the MainApplication... probably
-        // Also look up bridge-less mode.
         assertGoodTask(surface.prerender())
 
 

--- a/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
+++ b/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
@@ -1,106 +1,14 @@
 package com.rnstorybookautoscreenshots
 
-import android.app.Application
-import android.graphics.Color
-import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import com.facebook.react.PackageList
-import com.facebook.react.bridge.ReactMarker
-import com.facebook.react.bridge.ReactMarkerConstants
-import com.facebook.react.common.annotations.UnstableReactNativeAPI
-import com.facebook.react.bridge.JSBundleLoader
-import com.facebook.react.defaults.DefaultComponentsRegistry
-import com.facebook.react.defaults.DefaultReactHostDelegate
-import com.facebook.react.defaults.DefaultTurboModuleManagerDelegate
-import com.facebook.react.fabric.ComponentFactory
-import com.facebook.react.runtime.ReactHostImpl
-import com.facebook.react.runtime.hermes.HermesInstance
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import com.facebook.testing.screenshot.Screenshot
-import com.facebook.testing.screenshot.ViewHelpers
-import com.facebook.testing.screenshot.WindowAttachment
-import org.junit.Assert.*;
-import com.facebook.react.interfaces.*
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class IsolatedTest {
 
     @Test
-    fun simpleTest() {
-        assertTrue(true)
-    }
-
-    @OptIn(UnstableReactNativeAPI::class)
-    @Test
     fun constructViewTest() {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val context = instrumentation.targetContext
-        val app = context.applicationContext as Application
-
-        val bundleLoader = JSBundleLoader.createAssetLoader(
-            context, "assets://index.android.bundle", true)
-        val delegate = DefaultReactHostDelegate(
-            jsMainModulePath = "index",
-            jsBundleLoader = bundleLoader,
-            reactPackages = PackageList(app).packages,
-            jsRuntimeFactory = HermesInstance(),
-            turboModuleManagerDelegateBuilder = DefaultTurboModuleManagerDelegate.Builder(),
-            exceptionHandler = { throw it },
-        )
-        val componentFactory = ComponentFactory()
-        DefaultComponentsRegistry.register(componentFactory)
-        val reactHost = ReactHostImpl(
-            context,
-            delegate,
-            componentFactory,
-            false, // allowPackagerServerAccess
-            false, // useDevSupport
-        )
-
-        val surface = reactHost.createSurface(context, "SimpleTestComponent", null)
-        assertEquals("SimpleTestComponent", surface.moduleName)
-        assertNotNull(surface.view)
-
-        val view = surface.view!!
-
-        val renderLatch = CountDownLatch(1)
-        val markerListener = ReactMarker.MarkerListener { name, _, _ ->
-            if (name == ReactMarkerConstants.CONTENT_APPEARED) renderLatch.countDown()
-        }
-        ReactMarker.addListener(markerListener)
-
-        var detacher: WindowAttachment.Detacher? = null
-
-        try {
-            instrumentation.runOnMainSync {
-                reactHost.onHostResume(null)
-                view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
-                view.setBackgroundColor(Color.WHITE)
-                detacher = WindowAttachment.dispatchAttach(view)
-                ViewHelpers.setupView(view).setExactWidthPx(1080).setExactHeightPx(1920).layout()
-                surface.start()
-            }
-
-            assertTrue("Timed out waiting for first render", renderLatch.await(10, TimeUnit.SECONDS))
-            Screenshot.snap(view).record()
-        } finally {
-            ReactMarker.removeListener(markerListener)
-            instrumentation.runOnMainSync {
-                surface.stop()
-                detacher?.detach()
-            }
-        }
+        ReactHostFixture.screenshotComponent("SimpleTestComponent")
     }
-}
-
-fun assertGoodTask(ti : TaskInterface<Void>) {
-    ti.waitForCompletion()
-    assertFalse(ti.isFaulted())
-    assertTrue(ti.isCompleted())
 }

--- a/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
+++ b/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
@@ -2,6 +2,7 @@ package com.rnstorybookautoscreenshots
 
 import android.Manifest
 import android.app.Application
+import android.graphics.Color
 import android.graphics.PixelFormat
 import android.view.View
 import android.view.WindowManager
@@ -98,6 +99,7 @@ class IsolatedTest {
                 reactHost.onHostResume(null)
                 // Software rendering so Screenshot.snap() can capture via draw(canvas).
                 view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                view.setBackgroundColor(Color.WHITE)
                 wm.addView(view, params)
                 surface.start()
             }

--- a/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
+++ b/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
@@ -1,9 +1,16 @@
 package com.rnstorybookautoscreenshots
 
+import android.Manifest
 import android.app.Application
+import android.graphics.PixelFormat
+import android.view.View
+import android.view.WindowManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
 import com.facebook.react.PackageList
+import com.facebook.react.bridge.ReactMarker
+import com.facebook.react.bridge.ReactMarkerConstants
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.defaults.DefaultComponentsRegistry
@@ -14,15 +21,22 @@ import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.hermes.HermesInstance
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import com.facebook.testing.screenshot.ViewHelpers
 import com.facebook.testing.screenshot.Screenshot
 import org.junit.Assert.*;
 import com.facebook.react.interfaces.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class IsolatedTest {
+
+    @get:Rule
+    val overlayPermission: GrantPermissionRule =
+        GrantPermissionRule.grant(Manifest.permission.SYSTEM_ALERT_WINDOW)
+
     @Test
     fun simpleTest() {
         assertTrue(true)
@@ -31,7 +45,8 @@ class IsolatedTest {
     @OptIn(UnstableReactNativeAPI::class)
     @Test
     fun constructViewTest() {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
         val app = context.applicationContext as Application
 
         val bundleLoader = JSBundleLoader.createAssetLoader(
@@ -56,24 +71,47 @@ class IsolatedTest {
 
         val surface = reactHost.createSurface(context, "SimpleTestComponent", null)
         assertEquals("SimpleTestComponent", surface.moduleName)
-
-        // TODO: we aren't 100% sure if prerender() and start() are being called the way we want it to.
-        assertGoodTask(surface.prerender())
-
-
         assertNotNull(surface.view)
 
-        ViewHelpers.setupView(surface.view!!)
-            .setExactHeightPx(1000)
-            .setExactWidthPx(1000)
-            .layout()
+        val view = surface.view!!
+        val wm = context.getSystemService(android.content.Context.WINDOW_SERVICE) as WindowManager
+        val params = WindowManager.LayoutParams(
+            1080,
+            1920,
+            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            PixelFormat.TRANSLUCENT
+        ).apply {
+            // alpha=0 so the compositor skips drawing while Fabric still sees a real Window.
+            alpha = 0f
+        }
 
+        val renderLatch = CountDownLatch(1)
+        val markerListener = ReactMarker.MarkerListener { name, _, _ ->
+            if (name == ReactMarkerConstants.CONTENT_APPEARED) renderLatch.countDown()
+        }
+        ReactMarker.addListener(markerListener)
 
-        val ti = surface.start()
-        assertGoodTask(ti)
+        try {
+            instrumentation.runOnMainSync {
+                // RESUMED state is required for Fabric to commit mutations to the view.
+                reactHost.onHostResume(null)
+                // Software rendering so Screenshot.snap() can capture via draw(canvas).
+                view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                wm.addView(view, params)
+                surface.start()
+            }
 
-        Screenshot.snap(surface.view!!)
-            .record()
+            assertTrue("Timed out waiting for first render", renderLatch.await(10, TimeUnit.SECONDS))
+
+            Screenshot.snap(view).record()
+        } finally {
+            ReactMarker.removeListener(markerListener)
+            instrumentation.runOnMainSync {
+                surface.stop()
+                wm.removeView(view)
+            }
+        }
     }
 }
 

--- a/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
+++ b/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
@@ -1,14 +1,10 @@
 package com.rnstorybookautoscreenshots
 
-import android.Manifest
 import android.app.Application
 import android.graphics.Color
-import android.graphics.PixelFormat
 import android.view.View
-import android.view.WindowManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
 import com.facebook.react.PackageList
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarkerConstants
@@ -22,10 +18,11 @@ import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.hermes.HermesInstance
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import com.facebook.testing.screenshot.Screenshot
+import com.facebook.testing.screenshot.ViewHelpers
+import com.facebook.testing.screenshot.WindowAttachment
 import org.junit.Assert.*;
 import com.facebook.react.interfaces.*
 import java.util.concurrent.CountDownLatch
@@ -33,10 +30,6 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class IsolatedTest {
-
-    @get:Rule
-    val overlayPermission: GrantPermissionRule =
-        GrantPermissionRule.grant(Manifest.permission.SYSTEM_ALERT_WINDOW)
 
     @Test
     fun simpleTest() {
@@ -75,17 +68,6 @@ class IsolatedTest {
         assertNotNull(surface.view)
 
         val view = surface.view!!
-        val wm = context.getSystemService(android.content.Context.WINDOW_SERVICE) as WindowManager
-        val params = WindowManager.LayoutParams(
-            1080,
-            1920,
-            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
-            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
-            PixelFormat.TRANSLUCENT
-        ).apply {
-            // alpha=0 so the compositor skips drawing while Fabric still sees a real Window.
-            alpha = 0f
-        }
 
         val renderLatch = CountDownLatch(1)
         val markerListener = ReactMarker.MarkerListener { name, _, _ ->
@@ -93,25 +75,25 @@ class IsolatedTest {
         }
         ReactMarker.addListener(markerListener)
 
+        var detacher: WindowAttachment.Detacher? = null
+
         try {
             instrumentation.runOnMainSync {
-                // RESUMED state is required for Fabric to commit mutations to the view.
                 reactHost.onHostResume(null)
-                // Software rendering so Screenshot.snap() can capture via draw(canvas).
                 view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
                 view.setBackgroundColor(Color.WHITE)
-                wm.addView(view, params)
+                detacher = WindowAttachment.dispatchAttach(view)
+                ViewHelpers.setupView(view).setExactWidthPx(1080).setExactHeightPx(1920).layout()
                 surface.start()
             }
 
             assertTrue("Timed out waiting for first render", renderLatch.await(10, TimeUnit.SECONDS))
-
             Screenshot.snap(view).record()
         } finally {
             ReactMarker.removeListener(markerListener)
             instrumentation.runOnMainSync {
                 surface.stop()
-                wm.removeView(view)
+                detacher?.detach()
             }
         }
     }

--- a/android/app/src/androidTest/java/com/testapp/ReactHostFixture.kt
+++ b/android/app/src/androidTest/java/com/testapp/ReactHostFixture.kt
@@ -1,0 +1,105 @@
+package com.rnstorybookautoscreenshots
+
+import android.app.Application
+import android.graphics.Color
+import android.view.ContextThemeWrapper
+import android.view.View
+import androidx.test.platform.app.InstrumentationRegistry
+import com.facebook.react.PackageList
+import com.facebook.react.bridge.JSBundleLoader
+import com.facebook.react.bridge.ReactMarker
+import com.facebook.react.bridge.ReactMarkerConstants
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.defaults.DefaultComponentsRegistry
+import com.facebook.react.defaults.DefaultReactHostDelegate
+import com.facebook.react.defaults.DefaultTurboModuleManagerDelegate
+import com.facebook.react.fabric.ComponentFactory
+import com.facebook.react.runtime.ReactHostImpl
+import com.facebook.react.runtime.hermes.HermesInstance
+import com.facebook.testing.screenshot.Screenshot
+import com.facebook.testing.screenshot.ViewHelpers
+import com.facebook.testing.screenshot.WindowAttachment
+import com.testapp.R
+import junit.framework.TestCase.assertNotNull
+import org.junit.Assert.assertTrue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Shared ReactHostImpl for instrumentation tests.
+ *
+ * DefaultComponentsRegistry.register is a native JNI call that must only be invoked once
+ * per process. This singleton ensures all test classes share one ReactHostImpl instance
+ * instead of each creating their own.
+ */
+@OptIn(UnstableReactNativeAPI::class)
+object ReactHostFixture {
+    val reactHost: ReactHostImpl by lazy {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val app = context.applicationContext as Application
+
+        val bundleLoader = JSBundleLoader.createAssetLoader(
+            context, "assets://index.android.bundle", true)
+        val delegate = DefaultReactHostDelegate(
+            jsMainModulePath = "index",
+            jsBundleLoader = bundleLoader,
+            reactPackages = PackageList(app).packages,
+            jsRuntimeFactory = HermesInstance(),
+            turboModuleManagerDelegateBuilder = DefaultTurboModuleManagerDelegate.Builder(),
+            exceptionHandler = { throw it },
+        )
+        val componentFactory = ComponentFactory()
+        DefaultComponentsRegistry.register(componentFactory)
+        val host = ReactHostImpl(context, delegate, componentFactory, false, false)
+        instrumentation.runOnMainSync { host.onHostResume(null) }
+        host
+    }
+
+    /**
+     * Creates a surface for [componentName], waits for React to render via
+     * ReactMarker.CONTENT_APPEARED, snaps a screenshot, then tears down.
+     *
+     * Uses a themed context so Android widgets (Switch, etc.) can resolve
+     * their styled drawables.
+     */
+    @OptIn(UnstableReactNativeAPI::class)
+    fun screenshotComponent(componentName: String, screenshotName: String = componentName) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = ContextThemeWrapper(instrumentation.targetContext, R.style.AppTheme)
+
+        val surface = reactHost.createSurface(context, componentName, null)
+        assertNotNull(surface.view)
+        val view = surface.view!!
+
+        val renderLatch = CountDownLatch(1)
+        val markerListener = ReactMarker.MarkerListener { name, _, _ ->
+            if (name == ReactMarkerConstants.CONTENT_APPEARED) renderLatch.countDown()
+        }
+        ReactMarker.addListener(markerListener)
+
+        var detacher: WindowAttachment.Detacher? = null
+
+        try {
+            instrumentation.runOnMainSync {
+                view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                view.setBackgroundColor(Color.WHITE)
+                detacher = WindowAttachment.dispatchAttach(view)
+                ViewHelpers.setupView(view).setExactWidthPx(1080).setExactHeightPx(1920).layout()
+                surface.start()
+            }
+
+            assertTrue(
+                "Timed out waiting for render: $componentName",
+                renderLatch.await(10, TimeUnit.SECONDS)
+            )
+            Screenshot.snap(view).setName(screenshotName).record()
+        } finally {
+            ReactMarker.removeListener(markerListener)
+            instrumentation.runOnMainSync {
+                surface.stop()
+                detacher?.detach()
+            }
+        }
+    }
+}

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity android:name=".TestActivity" android:exported="false" />
+    </application>
+</manifest>

--- a/android/app/src/debug/java/com/testapp/TestActivity.kt
+++ b/android/app/src/debug/java/com/testapp/TestActivity.kt
@@ -1,0 +1,5 @@
+package com.testapp
+
+import android.app.Activity
+
+class TestActivity : Activity()

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
  * @format
  */
 
+import React, { useState } from 'react';
 import { AppRegistry, View, Text } from 'react-native';
 import { name as appName } from './app.json';
 
@@ -16,6 +17,54 @@ const { view } = require('./.rnstorybook/storybook.requires');
 
 const SimpleTestComponent = () => <View><Text>Hello</Text></View>;
 AppRegistry.registerComponent('SimpleTestComponent', () => SimpleTestComponent);
+
+const MyFeature = require('./MyFeature').default;
+const SwitchFeature = require('./SwitchFeature').default;
+const TimerFeature = require('./TimerFeature').default;
+const CoinFlipFeature = require('./CoinFlipFeature').default;
+const { Button } = require('./.rnstorybook/stories/Button');
+const { Header } = require('./.rnstorybook/stories/Header');
+
+const noop = () => {};
+
+// Base components
+AppRegistry.registerComponent('MyFeature', () => MyFeature);
+AppRegistry.registerComponent('SwitchFeature', () => SwitchFeature);
+AppRegistry.registerComponent('TimerFeature', () => TimerFeature);
+AppRegistry.registerComponent('CoinFlipFeature', () => CoinFlipFeature);
+AppRegistry.registerComponent('Button', () => Button);
+AppRegistry.registerComponent('Header', () => Header);
+
+// Button story variants
+AppRegistry.registerComponent('Button_Primary', () => () => <View style={{ flex: 1, alignItems: 'flex-start' }}><Button primary label="Button" onPress={noop} /></View>);
+AppRegistry.registerComponent('Button_Secondary', () => () => <View style={{ flex: 1, alignItems: 'flex-start' }}><Button label="Button" onPress={noop} /></View>);
+AppRegistry.registerComponent('Button_Large', () => () => <View style={{ flex: 1, alignItems: 'flex-start' }}><Button size="large" label="Button" onPress={noop} /></View>);
+AppRegistry.registerComponent('Button_Small', () => () => <View style={{ flex: 1, alignItems: 'flex-start' }}><Button size="small" label="Button" onPress={noop} /></View>);
+
+// Header story variants
+AppRegistry.registerComponent('Header_LoggedIn', () => () => <Header user={{ name: 'Jane Doe' }} onLogin={noop} onLogout={noop} onCreateAccount={noop} />);
+AppRegistry.registerComponent('Header_LoggedOut', () => () => <Header onLogin={noop} onLogout={noop} onCreateAccount={noop} />);
+
+// MyFeature story variants
+AppRegistry.registerComponent('MyFeature_Initial', () => () => { const [c, s] = useState(0); return <MyFeature clickCount={c} setClickCount={s} />; });
+AppRegistry.registerComponent('MyFeature_WithClicks', () => () => { const [c, s] = useState(5); return <MyFeature clickCount={c} setClickCount={s} />; });
+AppRegistry.registerComponent('MyFeature_ManyClicks', () => () => { const [c, s] = useState(42); return <MyFeature clickCount={c} setClickCount={s} />; });
+
+// SwitchFeature story variants
+AppRegistry.registerComponent('SwitchFeature_Off', () => () => { const [e, s] = useState(false); return <SwitchFeature isEnabled={e} setIsEnabled={s} />; });
+AppRegistry.registerComponent('SwitchFeature_On', () => () => { const [e, s] = useState(true); return <SwitchFeature isEnabled={e} setIsEnabled={s} />; });
+
+// TimerFeature story variants
+AppRegistry.registerComponent('TimerFeature_Initial', () => () => { const [sec, setSec] = useState(0); const [run, setRun] = useState(false); return <TimerFeature seconds={sec} setSeconds={setSec} isRunning={run} setIsRunning={setRun} />; });
+AppRegistry.registerComponent('TimerFeature_Running', () => () => <TimerFeature seconds={19} isRunning={true} setSeconds={noop} setIsRunning={noop} />);
+AppRegistry.registerComponent('TimerFeature_Paused', () => () => { const [sec, setSec] = useState(125); const [run, setRun] = useState(false); return <TimerFeature seconds={sec} setSeconds={setSec} isRunning={run} setIsRunning={setRun} />; });
+AppRegistry.registerComponent('TimerFeature_LongDuration', () => () => { const [sec, setSec] = useState(3661); const [run, setRun] = useState(false); return <TimerFeature seconds={sec} setSeconds={setSec} isRunning={run} setIsRunning={setRun} />; });
+
+// CoinFlipFeature story variants
+AppRegistry.registerComponent('CoinFlipFeature_Default', () => () => { const [r, setR] = useState(''); const [f, setF] = useState(0); return <CoinFlipFeature result={r} setResult={setR} flips={f} setFlips={setF} />; });
+AppRegistry.registerComponent('CoinFlipFeature_Heads', () => () => { const [r, setR] = useState('HEADS'); const [f, setF] = useState(5); return <CoinFlipFeature result={r} setResult={setR} flips={f} setFlips={setF} />; });
+AppRegistry.registerComponent('CoinFlipFeature_Tails', () => () => { const [r, setR] = useState('TAILS'); const [f, setF] = useState(10); return <CoinFlipFeature result={r} setResult={setR} flips={f} setFlips={setF} />; });
+AppRegistry.registerComponent('CoinFlipFeature_ManyFlips', () => () => { const [r, setR] = useState('HEADS'); const [f, setF] = useState(99); return <CoinFlipFeature result={r} setResult={setR} flips={f} setFlips={setF} />; });
 
 // Modes: 'app' | 'storybook'
 const MODE = 'app';


### PR DESCRIPTION
## Summary

- Adds `ReactHostFixture` singleton so `DefaultComponentsRegistry.register` (a JNI native call) is only invoked once per process
- Adds `ComponentSurfaceTest` parameterized over 25 story variants across all 6 components, matching the exact prop states from `.stories.tsx` files
- Simplifies `IsolatedTest` to delegate to the shared fixture
- Uses `ReactMarker.CONTENT_APPEARED` to reliably wait for React to render (fixes timeout issue with `viewTreeObserver`)
- Uses `ContextThemeWrapper(AppTheme)` so Android widgets like `Switch` get their styled drawables (fixes NPE crash)
- Registers all story variant components in `index.js`

## Test plan

- [ ] All 26 screenshots record successfully locally (`app:recordDebugAndroidTestScreenshotTest`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)