### PR TITLE
tidy: remove network image from SwitchFeature

### DIFF
--- a/SwitchFeature.tsx
+++ b/SwitchFeature.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, Switch, StyleSheet, Image } from 'react-native';
+import { View, Text, Switch, StyleSheet } from 'react-native';
 import { useTheme } from './Theme';
 
 type SwitchFeatureProps = {
@@ -31,15 +31,6 @@ export default function SwitchFeature({ isEnabled, setIsEnabled }: SwitchFeature
         {isEnabled ? '' : 'False'}
       </Text>
 
-      {/* Conditional image */}
-      {isEnabled && (
-        <Image
-          source={{
-            uri: 'https://preview.redd.it/morgan-freeman-true-3700-x-3700-v0-g0fa2kf347391.png?width=320&crop=smart&auto=webp&s=052771a34f448167b4c62c696dcd321b9e15cccb',
-          }}
-          style={styles.image}
-        />
-      )}
     </View>
   );
 }
@@ -59,12 +50,5 @@ const styles = StyleSheet.create({
   status: {
     marginTop: 10,
     fontSize: 16,
-  },
-  image: {
-    marginTop: 20,
-    width: 200,
-    height: 200,
-    resizeMode: 'contain',
-    borderRadius: 10,
   },
 });


### PR DESCRIPTION
## Summary

- Removes a Reddit image URL from `SwitchFeature` that was loaded conditionally when the switch is on
- The image made `SwitchFeature_On` screenshots non-deterministic in CI (image would never load, or load inconsistently depending on network)

## Test plan

- [ ] `SwitchFeature_On` screenshot no longer has a broken/empty image placeholder
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)