### PR TITLE
Investigate OnHierarchyChangeListener as readiness indicator for screenshot

### DIFF
--- a/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
+++ b/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
@@ -1,5 +1,9 @@
 package com.rnstorybookautoscreenshots
 
+import android.content.Context
+import android.graphics.Color
+import android.view.View
+import android.widget.FrameLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.testapp.MainApplication
@@ -9,8 +13,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import com.facebook.testing.screenshot.ViewHelpers
 import com.facebook.testing.screenshot.Screenshot
+import com.facebook.testing.screenshot.WindowAttachment
 import org.junit.Assert.*;
 import com.facebook.react.interfaces.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class IsolatedTest {
@@ -45,6 +52,60 @@ class IsolatedTest {
 
         Screenshot.snap(surface.view!!)
             .record()
+    }
+
+    @Test
+    fun addViewHookTest() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val app = context.applicationContext as MainApplication
+        val surface = app.reactHost.createSurface(context, "SimpleTestComponent", null)
+
+        val view = surface.view!! as android.view.ViewGroup
+        val latch = CountDownLatch(1)
+        var detacher: WindowAttachment.Detacher? = null
+
+        try {
+            instrumentation.runOnMainSync {
+                view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                view.setBackgroundColor(Color.WHITE)
+                view.setOnHierarchyChangeListener(object : android.view.ViewGroup.OnHierarchyChangeListener {
+                    override fun onChildViewAdded(parent: View, child: View) {
+                        view.setOnHierarchyChangeListener(null)
+                        latch.countDown()
+                    }
+                    override fun onChildViewRemoved(parent: View, child: View) {}
+                })
+                detacher = WindowAttachment.dispatchAttach(view)
+                app.reactHost.onHostResume(null)
+                ViewHelpers.setupView(view).setExactWidthPx(1080).setExactHeightPx(1920).layout()
+                surface.start()
+            }
+
+            assertTrue(
+                "Timed out waiting for Fabric to mount first child",
+                latch.await(30, TimeUnit.SECONDS)
+            )
+
+            instrumentation.runOnMainSync {
+                ViewHelpers.setupView(view).setExactWidthPx(1080).setExactHeightPx(1920).layout()
+                Screenshot.snap(view).setName("addViewHookTest").record()
+            }
+        } finally {
+            instrumentation.runOnMainSync {
+                surface.stop()
+                detacher?.detach()
+            }
+        }
+    }
+}
+
+class FirstChildLatch(context: Context) : FrameLayout(context) {
+    val latch = CountDownLatch(1)
+
+    override fun addView(child: View, index: Int, params: android.view.ViewGroup.LayoutParams) {
+        super.addView(child, index, params)
+        latch.countDown()
     }
 }
 

--- a/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
+++ b/android/app/src/androidTest/java/com/testapp/IsolatedTest.kt
@@ -55,6 +55,46 @@ class IsolatedTest {
     }
 
     @Test
+    fun hierarchyListenerTest() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val app = context.applicationContext as MainApplication
+        val surface = app.reactHost.createSurface(context, "SimpleTestComponent", null)
+
+        val view = surface.view!! as android.view.ViewGroup
+        val latch = CountDownLatch(1)
+        var detacher: WindowAttachment.Detacher? = null
+
+        try {
+            instrumentation.runOnMainSync {
+                view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+                view.setBackgroundColor(Color.WHITE)
+                view.setOnHierarchyChangeListener(object : android.view.ViewGroup.OnHierarchyChangeListener {
+                    override fun onChildViewAdded(parent: View, child: View) {
+                        view.setOnHierarchyChangeListener(null)
+                        latch.countDown()
+                    }
+                    override fun onChildViewRemoved(parent: View, child: View) {}
+                })
+                detacher = WindowAttachment.dispatchAttach(view)
+                app.reactHost.onHostResume(null)
+                ViewHelpers.setupView(view).setExactWidthPx(1080).setExactHeightPx(1920).layout()
+                surface.start()
+            }
+
+            assertTrue(
+                "Timed out waiting for Fabric to mount first child",
+                latch.await(30, TimeUnit.SECONDS)
+            )
+        } finally {
+            instrumentation.runOnMainSync {
+                surface.stop()
+                detacher?.detach()
+            }
+        }
+    }
+
+    @Test
     fun addViewHookTest() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext


### PR DESCRIPTION
## Summary

Companion to #111. Investigates `ViewGroup.setOnHierarchyChangeListener` as an event-driven alternative to polling `childCount > 0`.

- `hierarchyListenerTest`: asserts the listener fires when Fabric mounts its first child — no screenshot, just the indicator
- `addViewHookTest`: same setup, then re-layouts and snaps a screenshot

## Why

The `onChildViewAdded` callback fires synchronously the moment Fabric calls `addView` on the surface root — no polling loop needed. Uses a public Android API without subclassing.

## Test plan

- [ ] `hierarchyListenerTest` passes — confirms the signal is reachable
- [ ] `addViewHookTest` passes with non-blank screenshot ("Hello" visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)